### PR TITLE
Exception on comparing np arrays at several places

### DIFF
--- a/matid/classification/periodicfinder.py
+++ b/matid/classification/periodicfinder.py
@@ -835,7 +835,7 @@ class PeriodicFinder():
                 a_sub = adjacency_sub[i_basis][node]
                 if a_add:
                     a_add_neighbour, i_add_factor = a_add[0]
-                    if a_add_neighbour != node:
+                    if not np.array_equal(a_add_neighbour, node):
                         a_final_neighbour = a_add_neighbour
                         i_factor = i_add_factor
                         multiplier = 1

--- a/matid/classification/periodicfinder.py
+++ b/matid/classification/periodicfinder.py
@@ -650,13 +650,13 @@ class PeriodicFinder():
                 a_sub = adjacency_sub[i_basis][node]
                 if a_add:
                     a_add_neighbour, i_add_factor = a_add[0]
-                    if a_add_neighbour != node:
+                    if not np.array_equal(a_add_neighbour, node):
                         a_final_neighbour = a_add_neighbour
                         i_factor = i_add_factor
                         multiplier = 1
                 elif a_sub:
                     a_sub_neighbour, i_sub_factor = a_sub[0]
-                    if a_sub_neighbour != node:
+                    if not np.array_equal(a_sub_neighbour, node):
                         a_final_neighbour = a_sub_neighbour
                         i_factor = i_sub_factor
                         multiplier = -1
@@ -841,7 +841,7 @@ class PeriodicFinder():
                         multiplier = 1
                 elif a_sub:
                     a_sub_neighbour, i_sub_factor = a_sub[0]
-                    if a_sub_neighbour != node:
+                    if not np.array_equal(a_sub_neighbour, node):
                         a_final_neighbour = a_sub_neighbour
                         i_factor = i_sub_factor
                         multiplier = -1


### PR DESCRIPTION
When using the Classifier class to do a system type classification on ase.Atoms, we often get some exceptions like this:

```
Traceback (most recent call last):
  File "/app/nomad/normalizing/system.py", line 170, in normalize_system
    system_type = classifier.classify(atoms)
  File "/usr/local/lib/python3.6/site-packages/matid/classification/classifier.py", line 298, in classify
    dist_matrix_radii_pbc
  File "/usr/local/lib/python3.6/site-packages/matid/classification/classifier.py", line 443, in cross_validate_region
    dist_matrix_radii_pbc,
  File "/usr/local/lib/python3.6/site-packages/matid/classification/periodicfinder.py", line 134, in get_region
    bond_threshold
  File "/usr/local/lib/python3.6/site-packages/matid/classification/periodicfinder.py", line 504, in _find_proto_cell
    best_adjacency_lists_sub,
  File "/usr/local/lib/python3.6/site-packages/matid/classification/periodicfinder.py", line 659, in _find_proto_cell_3d
    if a_sub_neighbour != node:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

This merge requests, replaces the comparisons in question with `np.array_equal`. I am not sure if I caught all places or if the comparison should be done differently.